### PR TITLE
Skip PyPy builds

### DIFF
--- a/.ci_support/linux_python3.6.____cpython.yaml
+++ b/.ci_support/linux_python3.6.____cpython.yaml
@@ -14,3 +14,5 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython

--- a/.ci_support/linux_python3.7.____cpython.yaml
+++ b/.ci_support/linux_python3.7.____cpython.yaml
@@ -14,3 +14,5 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython

--- a/.ci_support/osx_python3.6.____cpython.yaml
+++ b/.ci_support/osx_python3.6.____cpython.yaml
@@ -18,3 +18,5 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython

--- a/.ci_support/osx_python3.7.____cpython.yaml
+++ b/.ci_support/osx_python3.7.____cpython.yaml
@@ -18,3 +18,5 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -10,3 +10,5 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -10,3 +10,5 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython

--- a/README.md
+++ b/README.md
@@ -179,6 +179,3 @@ Feedstock Maintainers
 * [@jakirkham](https://github.com/jakirkham/)
 * [@pitrou](https://github.com/pitrou/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/README.md
+++ b/README.md
@@ -179,3 +179,6 @@ Feedstock Maintainers
 * [@jakirkham](https://github.com/jakirkham/)
 * [@pitrou](https://github.com/pitrou/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py < 35 or py > 37]
+  skip: true  # [py < 35 or py > 37 or python_impl == "pypy"]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<35 or py>37]
+  skip: true  # [py < 35 or py > 37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
Skips PyPy builds as this is a CPython backport package that does not support PyPy.

<hr>

Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in #15.


Here's a checklist to do before merging.
- [ ] Bump the build number if needed.

Fixes #15